### PR TITLE
Add istio-vet as a supported command

### DIFF
--- a/istio/client.go
+++ b/istio/client.go
@@ -16,14 +16,14 @@ package istio
 
 import (
 	"k8s.io/client-go/dynamic"
-
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
 // IstioClient represents an Istio client in Meshery
 type IstioClient struct {
-	// k8s              *kube.Clientset
+	k8sClientset     *kubernetes.Clientset
 	k8sDynamicClient dynamic.Interface
 }
 
@@ -57,5 +57,12 @@ func newClient(kubeconfig []byte, contextName string) (*IstioClient, error) {
 		return nil, err
 	}
 	client.k8sDynamicClient = dynamicClient
+
+	k8sClientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	client.k8sClientset = k8sClientset
+
 	return &client, nil
 }

--- a/istio/config_templates/istio_vet.tmpl
+++ b/istio/config_templates/istio_vet.tmpl
@@ -1,0 +1,72 @@
+###############################
+# istio-vet RBAC
+##############################
+# Cluster wide get, list access for resources
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-vet-istio-system
+rules:
+- apiGroups: ["authentication.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["config.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["networking.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["rbac.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["config.istio.io"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources: ["thirdpartyresources", "thirdpartyresources.extensions", "ingresses", "ingresses/status", "deployments"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["configmaps", "endpoints", "pods", "services", "namespaces"]
+  verbs: ["get", "list", "watch"]
+---
+# Grant permissions to the istio-vet.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: istio-vet-istio-system
+subjects:
+- kind: ServiceAccount
+  name: istio-vet-service-account
+  namespace: {{.namespace}}
+roleRef:
+  kind: ClusterRole
+  name: istio-vet-istio-system
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: istio-vet-service-account
+  namespace: {{.namespace}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: istio-vet
+  namespace: {{.namespace}}
+spec:
+  template:
+    metadata:
+      labels:
+        app: istio-vet
+        istio: vet
+    spec:
+      containers:
+      - name: istio-vet
+        image: quay.io/aspenmesh/istio-vet:master
+        imagePullPolicy: IfNotPresent
+      restartPolicy: Never
+      serviceAccountName: istio-vet-service-account

--- a/istio/supported_ops.go
+++ b/istio/supported_ops.go
@@ -19,6 +19,10 @@ type supportedOperation struct {
 	name string
 	// the template file name
 	templateName string
+	// the app label
+	appLabel string
+	// returnLogs specifies if the operation logs should be returned
+	returnLogs bool
 }
 
 const customOpName = "custom"
@@ -27,6 +31,12 @@ var supportedOps = map[string]supportedOperation{
 	"istio_install": {
 		name:         "Install Istio",
 		templateName: "install_istio.tmpl",
+	},
+	"istio_vet": {
+		name:         "Run istio-vet",
+		templateName: "istio_vet.tmpl",
+		appLabel:     "istio-vet",
+		returnLogs:   true,
 	},
 	"cb1": {
 		name:         "Limit circuit breaker config to one connection",


### PR DESCRIPTION
This adds the `istio-vet` tool as a supported command by running it as a `Job` on demand. Later, the logs from the `Pod` are returned as response.