### PR TITLE
Always install SMI adapter into istio-system namespace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.13 as bd
-RUN adduser --disabled-login appuser
+RUN adduser --disabled-login --gecos "" appuser
 WORKDIR /github.com/layer5io/meshery-istio
 ADD . .
 RUN GOPROXY=direct GOSUMDB=off go build -ldflags="-w -s" -a -o /meshery-istio .

--- a/istio/istio.go
+++ b/istio/istio.go
@@ -503,9 +503,10 @@ func (iClient *IstioClient) ApplyOperation(ctx context.Context, arReq *meshes.Ap
 			return nil, err
 		}
 	case installSMI:
-		if !arReq.DeleteOp && arReq.Namespace != "default" {
-			iClient.createNamespace(ctx, arReq.Namespace)
-		}
+		// Always set the namespace for SMI adapter to istio-system
+		// as this is where istio is installed and how clusterrolebinding 
+		// for the SMI adapter is defined
+		arReq.Namespace = "istio-system"
 		yamlFileContents, err = getSMIYamls()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes https://github.com/layer5io/meshery-istio/issues/25

Additionally fixes minor annoyance with `adduser` utility asking for user details when running Docker build. 