### PR TITLE
Fix istio install and uninstall process

### DIFF
--- a/istio/error.go
+++ b/istio/error.go
@@ -26,9 +26,9 @@ var (
 	// when an invalid mesh config is found
 	ErrMeshConfigCode = "istio_test_code"
 
-	// ErrFetchManifestCode represents the errors which are generated
+	// ErrRunIstioCtlCmdCode represents the errors which are generated
 	// during fetch manifest process
-	ErrFetchManifestCode = "istio_test_code"
+	ErrRunIstioCtlCmdCode = "istio_test_code"
 
 	// ErrDownloadBinaryCode represents the errors which are generated
 	// during binary download process
@@ -99,9 +99,9 @@ func ErrMeshConfig(err error) error {
 	return errors.NewDefault(ErrMeshConfigCode, fmt.Sprintf("Error configuration mesh: %s", err.Error()))
 }
 
-// ErrFetchManifest is the error for mesh port forward
-func ErrFetchManifest(err error, des string) error {
-	return errors.NewDefault(ErrFetchManifestCode, fmt.Sprintf("Error fetching mesh manifest: %s", des))
+// ErrRunIstioCtlCmd is the error for mesh port forward
+func ErrRunIstioCtlCmd(err error, des string) error {
+	return errors.NewDefault(ErrRunIstioCtlCmdCode, fmt.Sprintf("Error running istioctl command: %s", des))
 }
 
 // ErrDownloadBinary is the error while downloading istio binary


### PR DESCRIPTION
Signed-off-by: Utkarsh Srivastava <srivastavautkarsh8097@gmail.com>

**Description**
This PR fixes the install and uninstall process. Before the release of meshkit v0.1.31 istio install and uninstall were working fine because meshkit was capable of rejecting invalid manifests. 
After the release of meshkit v0.1.31 it came into notice that the commands `istioctl install --set profile=demo -y` does **not** generate a manifest rather it triggers the install process. Similarly `istioctl x uninstall --purge -y` does **not** generate manifest rather initiate the uninstall process. 

This PR takes these things into consideration and no longer uses meshkit's `ApplyManifest` function for installation as `istioctl` is capable of doing so on it's own.

Tests done:
- [x] Test Istio installation and uninstallation outside the container
- [x] Test istio installation and uninstallation within the container (host network was used though)

**Notes for Reviewers**
I have removed the use of `ApplyManifest` as `istioctl` can handle the installation on its own. However, we can run `istioctl manifest generate` to get the manifest from the istioctl and apply it using `ApplyManifest`. Please suggest if we go for the manifest approach.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

