### PR TITLE
Meshworks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,11 @@ RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags="-w -
 FROM gcr.io/distroless/base
 ENV DISTRO="debian"
 ENV GOARCH="amd64"
+ENV SERVICE_ADDR="meshery-istio"
+ENV MESHERY_SERVER="http://meshery:9081"
 WORKDIR /templates
-COPY templates/* .
+COPY templates/* ./
 WORKDIR /
+COPY oam/ oam/
 COPY --from=builder /build/meshery-istio .
 ENTRYPOINT ["/meshery-istio"]

--- a/istio/error.go
+++ b/istio/error.go
@@ -74,9 +74,25 @@ var (
 	// during istio-vet process
 	ErrIstioVetCode = "istio_test_code"
 
+	// ErrParseOAMComponentCode represents the error code which is
+	// generated during the OAM component parsing
+	ErrParseOAMComponentCode = "istio_test_code"
+
+	// ErrParseOAMConfigCode represents the error code which is
+	// generated during the OAM configuration parsing
+	ErrParseOAMConfigCode = "istio_test_code"
+
 	// ErrOpInvalid represents the errors which are generated
 	// when an invalid operation is requested
 	ErrOpInvalid = errors.NewDefault(errors.ErrOpInvalid, "Invalid operation")
+
+	// ErrParseOAMComponent represents the error which is
+	// generated during the OAM component parsing
+	ErrParseOAMComponent = errors.NewDefault(ErrParseOAMComponentCode, "error parsing the component")
+
+	// ErrParseOAMConfig represents the error which is
+	// generated during the OAM configuration parsing
+	ErrParseOAMConfig = errors.NewDefault(ErrParseOAMConfigCode, "error parsing the configuration")
 )
 
 // ErrInstallIstio is the error for install mesh

--- a/istio/istio.go
+++ b/istio/istio.go
@@ -221,6 +221,23 @@ func (istio *Istio) ProcessOAM(ctx context.Context, oamReq adapter.OAMRequest) (
 		fmt.Println("error parsing the conifguration")
 	}
 
+	// If operation is delete then first HandleConfiguration and then handle the deployment
+	if oamReq.DeleteOp {
+		// Process configuration
+		msg2, err := istio.HandleApplicationConfiguration(config, oamReq.DeleteOp)
+		if err != nil {
+			return msg2, err
+		}
+
+		// Process components
+		msg1, err := istio.HandleComponents(comps, oamReq.DeleteOp)
+		if err != nil {
+			return msg1 + "\n" + msg2, err
+		}
+
+		return msg1 + "\n" + msg2, nil
+	}
+
 	// Process components
 	msg1, err := istio.HandleComponents(comps, oamReq.DeleteOp)
 	if err != nil {

--- a/istio/istio.go
+++ b/istio/istio.go
@@ -209,7 +209,7 @@ func (istio *Istio) ProcessOAM(ctx context.Context, oamReq adapter.OAMRequest) (
 	for _, acomp := range oamReq.OamComps {
 		comp, err := oam.ParseApplicationComponent(acomp)
 		if err != nil {
-			fmt.Println("error parsing the component")
+			istio.Log.Error(ErrParseOAMComponent)
 			continue
 		}
 
@@ -218,7 +218,7 @@ func (istio *Istio) ProcessOAM(ctx context.Context, oamReq adapter.OAMRequest) (
 
 	config, err := oam.ParseApplicationConfiguration(oamReq.OamConfig)
 	if err != nil {
-		fmt.Println("error parsing the conifguration")
+		istio.Log.Error(ErrParseOAMConfig)
 	}
 
 	// If operation is delete then first HandleConfiguration and then handle the deployment

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/layer5io/meshery-istio/istio"
@@ -102,12 +103,12 @@ func main() {
 	service.StartedAt = time.Now()
 
 	// Register workloads
-	if err := oam.RegisterWorkloads("http://localhost:9081", "mesherylocal.layer5.io:"+service.Port); err != nil {
+	if err := oam.RegisterWorkloads(mesheryServerAddress(), "mesherylocal.layer5.io:"+service.Port); err != nil {
 		fmt.Println(err)
 	}
 
 	// Register traits
-	if err := oam.RegisterTraits("http://localhost:9081", "mesherylocal.layer5.io:"+service.Port); err != nil {
+	if err := oam.RegisterTraits(mesheryServerAddress(), serviceAddress()+":"+service.Port); err != nil {
 		fmt.Println(err)
 	}
 
@@ -122,4 +123,28 @@ func main() {
 
 func isDebug() bool {
 	return os.Getenv("DEBUG") == "true"
+}
+
+func mesheryServerAddress() string {
+	meshReg := os.Getenv("MESHERY_SERVER")
+
+	if meshReg != "" {
+		if strings.HasPrefix(meshReg, "http") {
+			return meshReg
+		}
+
+		return "http://" + meshReg
+	}
+
+	return "http://localhost:9081"
+}
+
+func serviceAddress() string {
+	svcAddr := os.Getenv("SERVICE_ADDR")
+
+	if svcAddr != "" {
+		return svcAddr
+	}
+
+	return "mesherylocal.layer5.io"
 }

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func main() {
 	service.StartedAt = time.Now()
 
 	// Register workloads
-	if err := oam.RegisterWorkloads(mesheryServerAddress(), "mesherylocal.layer5.io:"+service.Port); err != nil {
+	if err := oam.RegisterWorkloads(mesheryServerAddress(), serviceAddress()+":"+service.Port); err != nil {
 		log.Info(err.Error())
 	}
 

--- a/main.go
+++ b/main.go
@@ -104,12 +104,12 @@ func main() {
 
 	// Register workloads
 	if err := oam.RegisterWorkloads(mesheryServerAddress(), "mesherylocal.layer5.io:"+service.Port); err != nil {
-		fmt.Println(err)
+		log.Info(err.Error())
 	}
 
 	// Register traits
 	if err := oam.RegisterTraits(mesheryServerAddress(), serviceAddress()+":"+service.Port); err != nil {
-		fmt.Println(err)
+		log.Info(err.Error())
 	}
 
 	// Server Initialization


### PR DESCRIPTION
**Description**

This PR fixes:
1. Previous meshworks PR missed out the considerations where the hostname for the service (istio adapter) as well as meshery server can change, this PR adds environmental variables and reasonable defaults to them in both dockerfile and `main.go`
2. Previous meshworks PR missed adding the newly added `oam` directory to the github image which this PR fixes.

Adds better handling of resource deletion, that is now it deletes traits first and then proceeds to delete the application.

**Notes for Reviewers**
Please let me know if the env vars defaults are reasonable. The defaults value for Dockerfile is picked from the meshery server's docker-compose.yaml while the defaults in the main.go are in accordance with the dev setup.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

