### PR TITLE
[Sample apps] fix sample app gateway manifests not getting applied

### DIFF
--- a/istio/sample_apps.go
+++ b/istio/sample_apps.go
@@ -19,7 +19,12 @@ func (istio *Istio) installSampleApp(namespace string, del bool, templates []ada
 	}
 
 	for _, template := range templates {
-		err := istio.applyManifest([]byte(template.String()), del, namespace)
+		contents, err := utils.ReadFileSource(string(template))
+		if err != nil {
+			return st, ErrSampleApp(err)
+		}
+
+		err = istio.applyManifest([]byte(contents), del, namespace)
 		if err != nil {
 			return st, ErrSampleApp(err)
 		}


### PR DESCRIPTION
Signed-off-by: Rudraksh Pareek <rudrakshpareek3601@gmail.com>

**Description**

This PR fixes #220

**Notes for Reviewers**
`template.String()` returns an empty string when trying to read local files referenced by a file URI (`file://path/to/file`).
The gateway manifests defined in templates were not getting applied because of this.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

