### PR TITLE
Revert "[Sample apps] fix sample app gateway manifests not getting applied"

### DIFF
--- a/istio/sample_apps.go
+++ b/istio/sample_apps.go
@@ -19,12 +19,7 @@ func (istio *Istio) installSampleApp(namespace string, del bool, templates []ada
 	}
 
 	for _, template := range templates {
-		contents, err := utils.ReadFileSource(string(template))
-		if err != nil {
-			return st, ErrSampleApp(err)
-		}
-
-		err = istio.applyManifest([]byte(contents), del, namespace)
+		err := istio.applyManifest([]byte(template.String()), del, namespace)
 		if err != nil {
 			return st, ErrSampleApp(err)
 		}


### PR DESCRIPTION
Reverts layer5io/meshery-istio#230 because we have updated `template.String()` in layer5io/meshery-adapter-library#52