### PR TITLE
Refactor OAM handler and add metadata for new Meshery UI

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,10 @@ const (
 	StrictMTLSPolicyOperation  = "strict-mtls-policy-operation"
 	MutualMTLSPolicyOperation  = "mutual-mtls-policy-operation"
 	DisableMTLSPolicyOperation = "disable-mtls-policy-operation"
+
+	// OAM Metadata constants
+	OAMAdapterNameMetadataKey       = "adapter.meshery.io/name"
+	OAMComponentCategoryMetadataKey = "ui.meshery.io/category"
 )
 
 var (

--- a/istio/error.go
+++ b/istio/error.go
@@ -90,6 +90,8 @@ var (
 	// generated when virtual service parsing fails
 	ErrParseVirtualServiceCode = "istio_test_code"
 
+	// ErrInvalidOAMComponentTypeCode represents the error code which is
+	// generated when an invalid oam component is requested
 	ErrInvalidOAMComponentTypeCode = "istio_test_code"
 
 	// ErrOpInvalid represents the errors which are generated

--- a/istio/error.go
+++ b/istio/error.go
@@ -90,6 +90,8 @@ var (
 	// generated when virtual service parsing fails
 	ErrParseVirtualServiceCode = "istio_test_code"
 
+	ErrInvalidOAMComponentTypeCode = "istio_test_code"
+
 	// ErrOpInvalid represents the errors which are generated
 	// when an invalid operation is requested
 	ErrOpInvalid = errors.NewDefault(errors.ErrOpInvalid, "Invalid operation")
@@ -190,4 +192,9 @@ func ErrIstioVet(err error) error {
 // ErrParseVirtualService is the error when vsc parsing fails
 func ErrParseVirtualService(err error) error {
 	return errors.NewDefault(ErrParseVirtualServiceCode, err.Error())
+}
+
+// ErrInvalidOAMComponentType is the error when the OAM component name is not valid
+func ErrInvalidOAMComponentType(compName string) error {
+	return errors.NewDefault(ErrInvalidOAMComponentTypeCode, "invalid OAM component name: ", compName)
 }

--- a/istio/oam.go
+++ b/istio/oam.go
@@ -11,46 +11,32 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type CompHandler func(*Istio, v1alpha1.Component, bool) (string, error)
+
 // HandleComponents handles the processing of OAM components
 func (istio *Istio) HandleComponents(comps []v1alpha1.Component, isDel bool) (string, error) {
 	var errs []error
 	var msgs []string
+
+	compFuncMap := map[string]CompHandler{
+		"IstioMesh":            handleComponentIstioMesh,
+		"VirtualService":       handleComponentVirtualService,
+		"GrafanaIstioAddon":    handleComponentIstioAddon,
+		"PrometheusIstioAddon": handleComponentIstioAddon,
+		"ZipkinIstioAddon":     handleComponentIstioAddon,
+		"JaegerIstioAddon":     handleComponentIstioAddon,
+	}
+
 	for _, comp := range comps {
-		if comp.Spec.Type == "IstioMesh" {
-			if err := handleComponentIstioMesh(istio, comp, isDel); err != nil {
-				errs = append(errs, err)
-			}
+		fnc, ok := compFuncMap[comp.Spec.Type]
+		if !ok {
 
-			msg := "created service of type \"IstioMesh\""
-			if isDel {
-				msg = "deleted service of type \"IstioMesh\""
-			}
-
-			msgs = append(msgs, msg)
-			continue
 		}
 
-		if comp.Spec.Type == "VirtualService" {
-			if err := handleComponentVirtualService(istio, comp, isDel); err != nil {
-				errs = append(errs, err)
-			}
-
-			msg := fmt.Sprintf("created virtual service \"%s\" in namespace \"%s\"", comp.Name, comp.Namespace)
-			if isDel {
-				msg = fmt.Sprintf("deleted virtual service \"%s\" in namespace \"%s\"", comp.Name, comp.Namespace)
-			}
-
-			msgs = append(msgs, msg)
-			continue
-		}
-
-		if err := handleComponentIstioAddon(istio, comp, isDel); err != nil {
+		msg, err := fnc(istio, comp, isDel)
+		if err != nil {
 			errs = append(errs, err)
-		}
-
-		msg := fmt.Sprintf("created service of type \"%s\"", comp.Spec.Type)
-		if isDel {
-			msg = fmt.Sprintf("deleted service of type \"%s\"", comp.Spec.Type)
+			continue
 		}
 
 		msgs = append(msgs, msg)
@@ -120,18 +106,16 @@ func handleNamespaceLabel(istio *Istio, namespaces []string, isDel bool) error {
 	return mergeErrors(errs)
 }
 
-func handleComponentIstioMesh(istio *Istio, comp v1alpha1.Component, isDel bool) error {
+func handleComponentIstioMesh(istio *Istio, comp v1alpha1.Component, isDel bool) (string, error) {
 	// Get the istio version from the settings
 	// we are sure that the version of istio would be present
 	// because the configuration is already validated against the schema
 	version := comp.Spec.Settings["version"].(string)
 
-	_, err := istio.installIstio(isDel, version, comp.Namespace)
-
-	return err
+	return istio.installIstio(isDel, version, comp.Namespace)
 }
 
-func handleComponentVirtualService(istio *Istio, comp v1alpha1.Component, isDel bool) error {
+func handleComponentVirtualService(istio *Istio, comp v1alpha1.Component, isDel bool) (string, error) {
 	virtualSvc := map[string]interface{}{
 		"apiVersion": "networking.istio.io/v1beta1",
 		"kind":       "VirtualService",
@@ -148,13 +132,18 @@ func handleComponentVirtualService(istio *Istio, comp v1alpha1.Component, isDel 
 	if err != nil {
 		err = ErrParseVirtualService(err)
 		istio.Log.Error(err)
-		return err
+		return "", err
 	}
 
-	return istio.applyManifest(yamlByt, isDel, comp.Namespace)
+	msg := fmt.Sprintf("created virtual service \"%s\" in namespace \"%s\"", comp.Name, comp.Namespace)
+	if isDel {
+		msg = fmt.Sprintf("deleted virtual service \"%s\" in namespace \"%s\"", comp.Name, comp.Namespace)
+	}
+
+	return msg, istio.applyManifest(yamlByt, isDel, comp.Namespace)
 }
 
-func handleComponentIstioAddon(istio *Istio, comp v1alpha1.Component, isDel bool) error {
+func handleComponentIstioAddon(istio *Istio, comp v1alpha1.Component, isDel bool) (string, error) {
 	var addonName string
 
 	switch comp.Spec.Type {
@@ -167,7 +156,7 @@ func handleComponentIstioAddon(istio *Istio, comp v1alpha1.Component, isDel bool
 	case "JaegerIstioAddon":
 		addonName = config.JaegerAddon
 	default:
-		return nil
+		return "", nil
 	}
 
 	// Get the service
@@ -184,7 +173,12 @@ func handleComponentIstioAddon(istio *Istio, comp v1alpha1.Component, isDel bool
 
 	_, err := istio.installAddon(comp.Namespace, isDel, svc, patches, templates)
 
-	return err
+	msg := fmt.Sprintf("created service of type \"%s\"", comp.Spec.Type)
+	if isDel {
+		msg = fmt.Sprintf("deleted service of type \"%s\"", comp.Spec.Type)
+	}
+
+	return msg, err
 }
 
 func castSliceInterfaceToSliceString(in []interface{}) []string {

--- a/istio/oam.go
+++ b/istio/oam.go
@@ -30,7 +30,7 @@ func (istio *Istio) HandleComponents(comps []v1alpha1.Component, isDel bool) (st
 	for _, comp := range comps {
 		fnc, ok := compFuncMap[comp.Spec.Type]
 		if !ok {
-
+			return "", ErrInvalidOAMComponentType(comp.Spec.Type)
 		}
 
 		msg, err := fnc(istio, comp, isDel)

--- a/istio/oam.go
+++ b/istio/oam.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+// CompHandler is the type for functions which can handle OAM components
 type CompHandler func(*Istio, v1alpha1.Component, bool) (string, error)
 
 // HandleComponents handles the processing of OAM components

--- a/istio/oam/register.go
+++ b/istio/oam/register.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
 )
@@ -46,10 +47,19 @@ func RegisterWorkloads(runtime, host string) error {
 	for _, workload := range workloads {
 		defintionPath, schemaPath := generatePaths(workloadPath, workload)
 
+		metadata := map[string]string{
+			"adapter.meshery.io/name": "istio",
+		}
+
+		if strings.HasSuffix(workload, "addon") {
+			metadata["ui.meshery.io/category"] = "addon"
+		}
+
 		oamRDP = append(oamRDP, adapter.OAMRegistrantDefinitionPath{
 			OAMDefintionPath: defintionPath,
 			OAMRefSchemaPath: schemaPath,
 			Host:             host,
+			Metadata:         metadata,
 		})
 	}
 
@@ -77,6 +87,9 @@ func RegisterTraits(runtime, host string) error {
 			OAMDefintionPath: defintionPath,
 			OAMRefSchemaPath: schemaPath,
 			Host:             host,
+			Metadata: map[string]string{
+				"adapter.meshery.io/name": "istio",
+			},
 		})
 	}
 

--- a/istio/oam/register.go
+++ b/istio/oam/register.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/layer5io/meshery-adapter-library/adapter"
+	"github.com/layer5io/meshery-istio/internal/config"
 )
 
 var (
@@ -48,11 +49,11 @@ func RegisterWorkloads(runtime, host string) error {
 		defintionPath, schemaPath := generatePaths(workloadPath, workload)
 
 		metadata := map[string]string{
-			"adapter.meshery.io/name": "istio",
+			config.OAMAdapterNameMetadataKey: config.IstioOperation,
 		}
 
 		if strings.HasSuffix(workload, "addon") {
-			metadata["ui.meshery.io/category"] = "addon"
+			metadata[config.OAMComponentCategoryMetadataKey] = "addon"
 		}
 
 		oamRDP = append(oamRDP, adapter.OAMRegistrantDefinitionPath{
@@ -88,7 +89,7 @@ func RegisterTraits(runtime, host string) error {
 			OAMRefSchemaPath: schemaPath,
 			Host:             host,
 			Metadata: map[string]string{
-				"adapter.meshery.io/name": "istio",
+				config.OAMAdapterNameMetadataKey: config.IstioOperation,
 			},
 		})
 	}


### PR DESCRIPTION
**Description**

This PR:
1. Refactors the OAM handler code to make it more generic
2. Adds some metadata which is used in the UI (the metadata except the adapter service mesh name is not required for the UI to work properly)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

